### PR TITLE
Amend bootstrap to run correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the Marklogic console. Run `docker-compose -f docker-marklogic.yml up` to bring 
 
 Once this is up you can create and restore the database from an s3 bucket containing test Judgments data:
 
-1. First, navigate to http://localhost:8001/, which will ask for basic auth. Username and password are both `admin`. 
+1. First, navigate to http://localhost:8001/, which will ask for basic auth. Username and password are both `admin`.
 2. Then add AWS credentials to MarkLogic (under Security > Credentials), so it can pull the backup from a shared S3 bucket.
    The credentials (AWS access ID & secret key) should be for your `dxwbilling` account. You will need to create them in AWS
    if you haven't already.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -42,10 +42,10 @@ python3 -m pip install --disable-pip-version-check -r requirements/local.txt 2>&
 	| sed	-e '/^Requirement already satisfied/d' \
 			-e '/don.t match your environment$/d'
 
-info 'Setting up DATABASE_URL...'
-export DATABASE_URL=$DATABASE_URL
 info 'Read .env file...'
 export DJANGO_READ_DOT_ENV_FILE=True
+info 'Setting up DATABASE_URL...'
+export DATABASE_URL=$DATABASE_URL
 info 'Create database...'
 createdb ds_judgements_public_ui -U postgres --no-password $DATABASE_PASSWORD 2>&1 \
   | sed -e '/database "ds_judgements_public_ui" already exists$/d'
@@ -53,7 +53,7 @@ info 'Migrate database...'
 python3 manage.py migrate
 
 info 'Create data volume for Marklogic'
-mkdir docker/db/data 2>&1 \
+mkdir -p docker/db/data 2>&1 \
   | sed -e '/File exists$/d'
 
 info 'Bring up Marklogic...'


### PR DESCRIPTION
Reorder telling Django to read from the .env file, and setting the
database url from the dot file.

When creating database backup in directory in docker, use the -p option
to create the backup directory parent.