### PR TITLE
Update README to re-add Marklogic information, plus add Marklogic bootstrap 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,19 @@ A database server built from the official [marklogic](https://hub.docker.com/_/m
 
 **NOTE**: For any of the following commands to work, you must first [install Fabric](https://www.fabfile.org/installing.html). Once installed, you can type `fab -l` to see a list of available commands.
 
-### 1. Gain access to the marklogic image
+### 1. Gain access to the Marklogic image
 
-Access to the marklogic Docker image is restricted to those who have 'purchased' it on Docker Hub. It's actually FREE to purchase, but you need to fill out [a short form](https://hub.docker.com/_/marklogic/purchase).
+Access to the Marklogic Docker image is restricted to those who have 'purchased' it on Docker Hub. It's actually FREE to
+purchase, but you need to fill out [a short form](https://hub.docker.com/_/marklogic/purchase).
 
 ### 2. Create `.env`
 
 ```console
 $ cp .env.example .env
 ```
+
+If you wish to use Marklogic in dev, set `MARKLOGIC_MOCK_REQUESTS` to False. See [Using Marklogic](#using-marklogic)
+for instructions on how to populate your Marklogic database with data.
 
 ### 3. Build Docker containers
 
@@ -82,7 +86,8 @@ $ python manage.py runserver_plus 0.0.0.0:3000
 
 ### Quick start with `fab run`
 
-While it's handy to be able to access the django container via a shell and interact with it directly, sometimes all you want is to view the site in a web browser. In these cases, you can use:
+While it's handy to be able to access the django container via a shell and interact with it directly, sometimes all you
+want is to view the site in a web browser. In these cases, you can use:
 
 ```console
 $ fab run
@@ -99,31 +104,51 @@ You can then access the site in your browser as usual:
 
 <http://127.0.0.1:3000>
 
+### Available Judgments
+
+- <http://127.0.0.1:3000/judgments/ewca/civ/2004/632>
+- <http://127.0.0.1:3000/judgments/ewca/civ/2004/811>
+- <http://127.0.0.1:3000/judgments/ewca/civ/2006/392>
+- <http://127.0.0.1:3000/judgments/ewca/civ/2007/214>
+
 ### Running tests
 
 ```console
 $ fab test
 ```
 
+## Using Marklogic
+
+If you wish to use Marklogic in development, you will need to run it in a Docker container of its own and populate
+it with data.
+
+### Bootstrap
+
+Run `script/bootstrap-marklogic` to create local storage directories and the REST Application server in Marklogic.
+You should only need to do this once.
+
 ### Importing Judgments data
 
-After running `script/bootstrap` you will need to create a database named `Judgments` in Marklogic. You can do this via
-the Marklogic console. Run `docker-compose -f docker-marklogic.yml up` to bring up Marklogic in its own container.
-
-Once this is up you can create and restore the database from an s3 bucket containing test Judgments data:
+Create a database in Marklogic and restore the data from an S3 bucket containing test Judgments data. Note that this
+bucket is currently only available to dxw developers.
 
 1. First, navigate to http://localhost:8001/, which will ask for basic auth. Username and password are both `admin`.
 2. Then add AWS credentials to MarkLogic (under Security > Credentials), so it can pull the backup from a shared S3 bucket.
    The credentials (AWS access ID & secret key) should be for your `dxwbilling` account. You will need to create them in AWS
    if you haven't already.
 3. Then create a database named `Judgments`in the Marklogic interface.
-4. After creating the database, attach a `Forest` named `Judgments1`. The interface should tell you that the database does not have any Forests attached. To create this Forest click on the link provided within the interface, or click in the Forest folder and follow the instructions.
+4. After creating the database, attach a `Forest` named `Judgments1`. The interface should tell you that the database
+   does not have any Forests attached. To create this Forest click on the link provided within the interface, or click in
+   the Forest folder and follow the instructions.
 5. In the Backup/Restore tab in Marklogic for your new Judgments database, initiate a restore, using the following as the
    `"directory": s3://tna-judgments-marklogic-backup/`
 
 Assuming you have entered the S3 credentials correctly, this will kick off a restore from s3. Once you have the data locally,
 you can then back it up locally using the path `/var/opt/backup` in the management console. It will be backed up to your local
 machine in `docker/db/backup`
+
+Once Marklogic is set up, change `MARKLOGIC_MOCK_REQUESTS` to False and the application will read data from Marklogic
+instead of the file system.
 
 ### Marklogic URL Guide
 
@@ -133,6 +158,6 @@ machine in `docker/db/backup`
 - http://localhost:8011/ this is the application server for the Marklogic REST interface
 All four URLs use basic auth, username and passward are both `admin`.
 
-### Using the pre-push hook (optional)
+## Using the pre-push hook (optional)
 
 Copy `pre-push.sample` to `.git/hooks/pre-push` to set up the pre-push hook. This will run Python linting and style checks when you push to the repo and alert you to any linting issues that will cause CI to fail.

--- a/script/bootstrap-marklogic
+++ b/script/bootstrap-marklogic
@@ -1,0 +1,45 @@
+#!/bin/sh
+# vim: set ts=4:
+#
+# Ensures that Python 3.9 is available and installs modules specified
+# in requirements-dev.txt.
+#
+# Environment variables:
+#   PYTHON : Python executable to use (default is python3 or python on PATH).
+#
+# This script follows convention https://github.com/github/scripts-to-rule-them-all.
+set -eu
+
+cd "$(dirname "$0")/.."
+. script/utils.sh
+. .env
+
+info 'Create data volume for Marklogic'
+mkdir -p docker/db/data 2>&1 \
+  | sed -e '/File exists$/d'
+
+info 'Bring up Marklogic...'
+docker-compose -f docker-marklogic.yml up -d > marklogic.log
+
+info 'Check to see if Marklogic is up...'
+while ! curl -X GET http://localhost:8002/v1/rest-apis 2>&1 | sed -e '/401 Unauthorized/d'
+do
+  sleep 1
+  echo 'Waiting for Marklogic to come up'
+done
+
+info 'Create Application server on Marklogic...'
+  curl -v -X POST  --anyauth -u admin:admin \
+  --header "Content-Type:application/json" \
+  -d '{"rest-api": { "name": "JudgmentsServer", "port": "8011", "database": "Judgments", "modules-database": "Modules" } }' \
+  'http://localhost:8002/v1/rest-apis' 2>&1 \
+  | sed -e '/Port 8011 is in use./d' # This message means the application server already exists
+
+info 'Adjust Application server authentication to be basicauth...'
+  curl -v -X PUT  --anyauth -u admin:admin \
+  --header "Content-Type:application/json" \
+  -d '{"authentication": "basic" }' \
+  'http://localhost:8002/manage/v2/servers/JudgmentsServer/properties?group-id=Default' 2>&1 \
+  | sed -e '/204 No Content/d'
+
+info 'Marklogic Application server created'

--- a/script/utils.sh
+++ b/script/utils.sh
@@ -1,0 +1,24 @@
+# vim: set ts=4:
+
+info() {
+	# bold cyan
+	printf '\033[1;36m> %s\033[0m\n' "$@" >&2
+}
+
+warn() {
+	# bold yellow
+	printf '\033[1;33m> %s\033[0m\n' "$@" >&2
+}
+
+die() {
+	# bold red
+	printf '\033[1;31mERROR:\033[0m %s\n' "$1" >&2
+	exit ${2:-2}
+}
+
+is_on_path() {
+	case "$PATH" in
+		*$1:*) return 0;;
+		*) return 1;;
+	esac
+}


### PR DESCRIPTION
Re-add the information about setting up Marklogic to the README. 

Add a `marklogic-bootstrap` script to set up the environment for Marklogic, and create an Application server. 