### PR TITLE
Add Index page to application

### DIFF
--- a/ds_judgements_public_ui/templates/judgment/index.html
+++ b/ds_judgements_public_ui/templates/judgment/index.html
@@ -1,9 +1,18 @@
 {% extends "base.html" %}
 {% block content %}
-  Total judgements: {{ judgement_list.count }}
-  <ul>
-    {% for judgement in judgement_list %}
-      <li>{{ judgement.title }}</li>
-    {% endfor %}
-  </ul>
+Total number of documents: {{ context.total }}
+<ul>
+  {% for result in context.search_results %}
+    <li>
+      <a href="{% url 'detail' result.uri %}">{{ result.name }} - {{ result.neutral_citation }}</a>
+    </li>
+  {% endfor %}
+</ul>
+
+{% if context.page == 1 %}
+  Previous page | <a href="{% url 'index' page=2 %}">Next page</a>
+{% else %}
+
+  <a href="{% url 'index' page=context.prev_page %}">Previous page</a> | <a href="{% url 'index' page=context.next_page %}">Next page</a>
+{% endif %}
 {% endblock content %}

--- a/judgments/api_client.py
+++ b/judgments/api_client.py
@@ -108,7 +108,7 @@ class MarklogicApiClient:
     def PUT(self, path: str, **data: Any) -> requests.Response:
         return self.make_request("PUT", path, data)
 
-    def get_judgement_xml(self, uri: str) -> str:
+    def get_judgment_xml(self, uri: str) -> str:
         return self.GET(f"LATEST/documents/?uri=/{uri.lstrip('/')}.xml", False).text
 
     def get_judgment_search_results(self, page: str) -> requests.Response:
@@ -120,7 +120,7 @@ class MockAPIClient:
 
     fixtures_dir: str = settings.MARKLOGIC_FIXTURES_DIR
 
-    def get_judgement_xml(self, uri: str) -> str:
+    def get_judgment_xml(self, uri: str) -> str:
         filepath = os.path.join(self.fixtures_dir, uri.lstrip("/") + ".xml")
 
         try:

--- a/judgments/fixtures/search/results1.xml
+++ b/judgments/fixtures/search/results1.xml
@@ -1,0 +1,57 @@
+<search:response snippet-format="snippet" total="48874" start="1" page-length="10" xmlns:search="http://marklogic.com/appservices/search">
+  <search:result index="1" uri="/ewca/civ/2004/632.xml" path="fn:doc(&quot;/ewca/civ/2004/632.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewca%2Fciv%2F2004%2F632.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewca/civ/2004/632.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="2" uri="/ewca/civ/2009/941.xml" path="fn:doc(&quot;/ewca/civ/2009/941.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewca%2Fciv%2F2009%2F941.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewca/civ/2009/941.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="3" uri="/ewhc/qb/2020/594.xml" path="fn:doc(&quot;/ewhc/qb/2020/594.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fqb%2F2020%2F594.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/qb/2020/594.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="4" uri="/ewca/civ/2007/214.xml" path="fn:doc(&quot;/ewca/civ/2007/214.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewca%2Fciv%2F2007%2F214.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewca/civ/2007/214.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="5" uri="/ewhc/ch/2004/2699.xml" path="fn:doc(&quot;/ewhc/ch/2004/2699.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fch%2F2004%2F2699.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/ch/2004/2699.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="6" uri="/ewhc/admin/2008/524.xml" path="fn:doc(&quot;/ewhc/admin/2008/524.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fadmin%2F2008%2F524.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/admin/2008/524.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="7" uri="/ewhc/ch/2020/1169.xml" path="fn:doc(&quot;/ewhc/ch/2020/1169.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fch%2F2020%2F1169.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/ch/2020/1169.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="8" uri="/ewca/civ/2009/328.xml" path="fn:doc(&quot;/ewca/civ/2009/328.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewca%2Fciv%2F2009%2F328.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewca/civ/2009/328.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="9" uri="/ewca/civ/2011/682.xml" path="fn:doc(&quot;/ewca/civ/2011/682.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewca%2Fciv%2F2011%2F682.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewca/civ/2011/682.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="10" uri="/ewhc/admin/2006/3144.xml" path="fn:doc(&quot;/ewhc/admin/2006/3144.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fadmin%2F2006%2F3144.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/admin/2006/3144.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:metrics>
+    <search:query-resolution-time>PT0.045687S</search:query-resolution-time>
+    <search:snippet-resolution-time>PT0.002984S</search:snippet-resolution-time>
+    <search:total-time>PT0.0607S</search:total-time>
+  </search:metrics>
+</search:response>

--- a/judgments/fixtures/search/results2.xml
+++ b/judgments/fixtures/search/results2.xml
@@ -1,0 +1,57 @@
+<search:response snippet-format="snippet" total="48874" start="2" page-length="10" xmlns:search="http://marklogic.com/appservices/search">
+  <search:result index="2" uri="/ewca/civ/2009/941.xml" path="fn:doc(&quot;/ewca/civ/2009/941.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewca%2Fciv%2F2009%2F941.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewca/civ/2009/941.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="3" uri="/ewhc/qb/2020/594.xml" path="fn:doc(&quot;/ewhc/qb/2020/594.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fqb%2F2020%2F594.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/qb/2020/594.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="4" uri="/ewca/civ/2007/214.xml" path="fn:doc(&quot;/ewca/civ/2007/214.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewca%2Fciv%2F2007%2F214.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewca/civ/2007/214.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="5" uri="/ewhc/ch/2004/2699.xml" path="fn:doc(&quot;/ewhc/ch/2004/2699.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fch%2F2004%2F2699.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/ch/2004/2699.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="6" uri="/ewhc/admin/2008/524.xml" path="fn:doc(&quot;/ewhc/admin/2008/524.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fadmin%2F2008%2F524.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/admin/2008/524.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="7" uri="/ewhc/ch/2020/1169.xml" path="fn:doc(&quot;/ewhc/ch/2020/1169.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fch%2F2020%2F1169.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/ch/2020/1169.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="8" uri="/ewca/civ/2009/328.xml" path="fn:doc(&quot;/ewca/civ/2009/328.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewca%2Fciv%2F2009%2F328.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewca/civ/2009/328.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="9" uri="/ewca/civ/2011/682.xml" path="fn:doc(&quot;/ewca/civ/2011/682.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewca%2Fciv%2F2011%2F682.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewca/civ/2011/682.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="10" uri="/ewhc/admin/2006/3144.xml" path="fn:doc(&quot;/ewhc/admin/2006/3144.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fadmin%2F2006%2F3144.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/admin/2006/3144.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:result index="11" uri="/ewhc/ch/2006/2110.xml" path="fn:doc(&quot;/ewhc/ch/2006/2110.xml&quot;)" score="0" confidence="0" fitness="0" href="/v1/documents?uri=%2Fewhc%2Fch%2F2006%2F2110.xml" mimetype="application/xml" format="xml">
+    <search:snippet>
+      <search:match path="fn:doc(&quot;/ewhc/ch/2006/2110.xml&quot;)/*:akomaNtoso"/>
+    </search:snippet>
+  </search:result>
+  <search:metrics>
+    <search:query-resolution-time>PT0.005356S</search:query-resolution-time>
+    <search:snippet-resolution-time>PT0.0023S</search:snippet-resolution-time>
+    <search:total-time>PT0.491394S</search:total-time>
+  </search:metrics>
+</search:response>

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -3,6 +3,8 @@ from django.urls import path, re_path
 from . import views
 
 urlpatterns = [
+    path("", views.index, name="index"),
+    path("<page>", views.index, name="index"),
     re_path("(?P<judgment_uri>.*/.*/.*)", views.detail, name="detail"),
     path("source", views.source, name="source"),
     path("structured_search", views.structured_search, name="structured_search"),

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -11,11 +11,11 @@ from judgments.api_client import MarklogicResourceNotFoundError, api_client
 
 def detail(request, judgment_uri):
     try:
-        judgement_xml = api_client.get_judgement_xml(judgment_uri)
+        judgment_xml = api_client.get_judgment_xml(judgment_uri)
     except MarklogicResourceNotFoundError:
         raise Http404("Judgment was not found")
     template = loader.get_template("judgment/detail.html")
-    return HttpResponse(template.render({"xml": judgement_xml}, request))
+    return HttpResponse(template.render({"xml": judgment_xml}, request))
 
 
 def index(request, page=1):

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -1,18 +1,91 @@
+import re
+
+import xmltodict
 from django.http import Http404, HttpResponse
 from django.template import loader
+from lxml import etree
+from requests_toolbelt.multipart import decoder
 
 from judgments.api_client import MarklogicResourceNotFoundError, api_client
 
 
 def detail(request, judgment_uri):
-    if judgment_uri.endswith("/"):
-        judgment_uri = judgment_uri[:-1]
     try:
         judgement_xml = api_client.get_judgement_xml(judgment_uri)
     except MarklogicResourceNotFoundError:
         raise Http404("Judgment was not found")
     template = loader.get_template("judgment/detail.html")
     return HttpResponse(template.render({"xml": judgement_xml}, request))
+
+
+def index(request, page=1):
+    try:
+        results = api_client.get_judgment_search_results(page)
+        if type(results) == str:
+            xml_results = xmltodict.parse(results)
+            total = xml_results["search:response"]["@total"]
+            search_results = xml_results["search:response"]["search:result"]
+
+            search_results = [
+                {
+                    "uri": result["@uri"],
+                    "neutral_citation": result["@uri"].split(".xml")[0],
+                    "name": "Fake Judgment name",
+                }
+                for result in search_results
+            ]
+        else:
+            multipart_data = decoder.MultipartDecoder.from_response(results)
+
+            search_metadata = xmltodict.parse(multipart_data.parts[0].text)
+            total = search_metadata["search:response"]["@total"]
+
+            search_results = []
+
+            for part in multipart_data.parts[1::]:
+                metadata = part.headers
+                content_disposition = metadata[b"Content-Disposition"].decode("utf-8")
+                filename = re.search('filename="([^"]*)"', content_disposition).group(1)
+                filename = filename.split(".xml")[0]
+                xml = etree.XML(bytes(part.text, encoding="utf8"))
+                neutral_citation = xml.xpath(
+                    "//akn:neutralCitation",
+                    namespaces={
+                        "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                    },
+                )
+                name = xml.xpath(
+                    "//akn:FRBRname/@value",
+                    namespaces={
+                        "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                    },
+                )[0]
+
+                if not neutral_citation:
+                    neutral_citation = filename
+                else:
+                    neutral_citation = neutral_citation[0].text
+
+                search_results.append(
+                    {
+                        "uri": filename,
+                        "neutral_citation": neutral_citation,
+                        "name": name,
+                    }
+                )
+
+        context = {
+            "total": total,
+            "search_results": search_results,
+            "page": page,
+            "prev_page": int(page) - 1,
+            "next_page": int(page) + 1,
+        }
+
+    except MarklogicResourceNotFoundError:
+        raise Http404("Search results not found")
+    template = loader.get_template("judgment/index.html")
+    return HttpResponse(template.render({"context": context}, request))
 
 
 def source():

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,3 +18,5 @@ django-redis==5.2.0  # https://github.com/jazzband/django-redis
 
 requests~=2.27.1
 xmltodict~=0.12.0
+requests-toolbelt~=0.9.1
+lxml~=4.7.1


### PR DESCRIPTION
Add an index page to the application, with basic pagination.

In Marklogic-using mode, this will retrieve judgments 10 at a time and present
them in a simple list with pagination.

<img width="1537" alt="Screenshot 2022-02-14 at 14 21 15" src="https://user-images.githubusercontent.com/1089521/153895248-8a7c0348-34db-4b74-bc69-163f941aa5ca.png">

In mocked Marklogic mode, this will present 2 pages of static search results,
retrieved from the fixtures directory.

Note: in non-Marklogic mode, the data returned is simplified, and is missing the Judgment name. I decided to go this route as mocking a `multipart/mixed` response with the `MockAPIClient` proved quite tricky, and instead I'm returning a string, which the view parses as a simplified list of results. This should be adequate for styling purposes. 

<img width="1058" alt="Screenshot 2022-02-14 at 15 36 33" src="https://user-images.githubusercontent.com/1089521/153895293-88bb6471-8ff5-45f1-b127-f3084f4ff90d.png">

