### PR TITLE
Apply Flask Templates

### DIFF
--- a/ds_judgements_public_ui/templates/base.html
+++ b/ds_judgements_public_ui/templates/base.html
@@ -10,18 +10,24 @@
     <link rel="icon" href="{% static 'images/favicons/favicon.png' %}">
 
     {% block css %}
-    <link href="{% static 'css/main.css' %}" rel="stylesheet">
+      <link href="{% static 'css/main.css' %}" rel="stylesheet">
     {% endblock %}
 
     {% block javascript %}
       <script defer src="{% static 'js/dist/app.js' %}"></script>
     {% endblock javascript %}
 
+    {% include 'includes/gtm/gtm_head.html' %}
   </head>
 
   <body>
+    <a id="skip-to-main-content" href="#main-content">Skip to Main Content</a>
+    {% include 'includes/gtm/gtm_body.html' %}
+    {% include 'includes/phase_banner.html' %}
+    <main id="main-content">
       {% block content %}
-
       {% endblock content %}
+    </main>
+    {% include 'includes/footer.html' %}
   </body>
 </html>

--- a/ds_judgements_public_ui/templates/includes/basic_search_form.html
+++ b/ds_judgements_public_ui/templates/includes/basic_search_form.html
@@ -1,0 +1,20 @@
+<div class="search-component">
+  <div class="search-component__container">
+    <h2 class="search-component__header--sr-only">Search by keyword or neutral citation</h2>
+    <form action="{# {% url 'results' %} #}" role="search" aria-label="Search by keyword or neutral citation" id="analytics-basic-search">
+
+      <label for="search_term" class="search-component__search-term-label">{# {{ form.search_term.label }} #}</label>
+      {# {{ form.search_term(placeholder="Enter a keyword or neutral citation") }} #}
+      <input type="submit" value="Search">
+      <div>
+        {# {{ form.neutral_citation }} #}
+        {# {{ form.neutral_citation.label }} #}
+      </div>
+
+    </form>
+
+    <div class="search-component__more-options">
+      <a href="{% url 'structured_search' %}">More search options</a>
+    </div>
+  </div>
+</div>

--- a/ds_judgements_public_ui/templates/includes/browse_by_court.html
+++ b/ds_judgements_public_ui/templates/includes/browse_by_court.html
@@ -1,0 +1,23 @@
+{% block content %}
+  <div class="judgment-browse-by-court">
+    <div class="judgment-browse-by-court__container">
+      <h2 id="browse-by-court" class="judgment-browse-by-court__header">Find judgments by court</h2>
+
+      <ul class="judgment-browse-by-court__list">
+        {% for court in courts %}
+        {# {% for court in courts | sort(attribute='name') %} #}
+          <li class="judgment-browse-by-court__court">
+            <span class="judgment-browse-by-court__court-name">
+                <a class="judgment-browse-by-court__court-link" href="/results?courts={{ court.code }}">
+                  {{ court.name }}
+                </a>
+            </span>
+            <span class="judgment-browse-by-court__years">
+              ({{ court.years_range_start }} - {{ court.years_range_end }})
+            </span>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+{% endblock %}

--- a/ds_judgements_public_ui/templates/includes/footer.html
+++ b/ds_judgements_public_ui/templates/includes/footer.html
@@ -1,0 +1,14 @@
+<footer class="judgments-footer">
+  <div class="judgments-footer__container">
+    <h2 class="judgments-footer__heading">Footer</h2>
+    <ul class="judgments-footer__links">
+      <li>All content is available under the
+        <a class="judgments-footer__link" href="{% url 'open_justice_licence' %}">Open Justice Licence</a>,
+        except where otherwise stated.
+      </li>
+      <li>
+        <a class="judgments-footer__link" href="{% url 'terms_of_use' %}">Terms of use</a>
+      </li>
+    </ul>
+  </div>
+</footer>

--- a/ds_judgements_public_ui/templates/includes/logo.html
+++ b/ds_judgements_public_ui/templates/includes/logo.html
@@ -1,0 +1,6 @@
+
+<div class="page-header__container">
+  <a class="page-header__logo-link" href="{% url 'home' %}">
+    <img class="page-header__logo" src="{# {% url 'static' filename='tna_logo.svg' %} #}" alt="The National Archives home" width="320" height="44">
+  </a>
+</div>

--- a/ds_judgements_public_ui/templates/includes/phase_banner.html
+++ b/ds_judgements_public_ui/templates/includes/phase_banner.html
@@ -1,0 +1,12 @@
+<div class="phase-banner">
+  <div class="phase-banner__container">
+    <div class="phase-banner__notice">
+      <strong class="phase-banner__phase">BETA</strong>
+      <p class="phase-banner__message">
+        This is a new service – your
+        <a target="_blank" rel="noreferrer noopener" href="https://www.smartsurvey.co.uk/s/readingroomvisitbooking/">feedback</a>
+        will help us to improve it.
+      </p>
+    </div>
+  </div>
+</div>

--- a/ds_judgements_public_ui/templates/includes/recent_judgments.html
+++ b/ds_judgements_public_ui/templates/includes/recent_judgments.html
@@ -1,0 +1,30 @@
+<div class="recent-judgments">
+  <div class="recent-judgments__container">
+    <h2 id="recently-published-judgments" class="recent-judgments__header">Recently published judgments</h2>
+    <ul class="recent-judgments__list">
+      {% for item in recent_judgments %}
+        <li class="recent-judgments__judgment">
+          <span>
+            <span class="recent-judgments__title">
+              <a href="/judgment">
+                {{ item.title }}
+              </a>
+            </span>
+            <span class="recent-judgments__neutralcitation">
+              {{ item.neutral_citation }}
+            </span>
+          </span>
+          <span>
+            <span class="recent-judgments__date">
+              Date: {{ item.date }}
+            </span>
+            <span class="recent-judgments__court">
+              Court: {{ item.court }}
+            </span>
+          </span>
+        </li>
+      {% endfor %}
+    </ul>
+    <p class="recent-judgments__more-info"><a href="{# {% url 'results' order_by='date_dec' %} #}">See all recent judgments</a></p>
+  </div>
+</div>

--- a/ds_judgements_public_ui/templates/includes/sources_introduction.html
+++ b/ds_judgements_public_ui/templates/includes/sources_introduction.html
@@ -1,0 +1,6 @@
+<div class="sources-introduction">
+  <div class="sources-introduction__container">
+    <h2 class="sources-introduction__header">Sources</h2>
+    <p>Copy introducing and thanking the suppliers and sources of judgments. <a href="{# {% url 'sources' %} #}" class="sources-introduction__link">See all sources of judgments</a></p>
+  </div>
+</div>

--- a/ds_judgements_public_ui/templates/pages/home.html
+++ b/ds_judgements_public_ui/templates/pages/home.html
@@ -1,1 +1,31 @@
 {% extends "base.html" %}
+
+{% block content %}
+    <header class="page-header">
+      <div class="page-header__breadcrumb">
+        <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
+          <ol>
+            <li><a href="https://www.nationalarchives.gov.uk">Home</a></li>
+            <li><a href="{% url 'home' %}" aria-current="page">{{ service.name }}</a></li>
+          </ol>
+        </nav>
+      </div>
+
+     {% include 'includes/logo.html' %}
+
+    </header>
+
+    <div class="service-introduction">
+        <div class="service-introduction__container">
+            <span class="service-introduction__separator"></span>
+            <h1 class="service-introduction__header">{{ service.name }}</h1>
+            <p class="service-introduction__helper-text">
+                Use this service to find, view and download judgments and tribunal decisions<br>
+            </p>
+        </div>
+    </div>
+    {% include 'includes/basic_search_form.html' %}
+    {% include 'includes/recent_judgments.html' %}
+    {% include 'includes/browse_by_court.html' %}
+    {% include 'includes/sources_introduction.html' %}
+{% endblock %}


### PR DESCRIPTION
Import the home template from the flask application along with all the other template files which are required.
The layout template from the flask app has imported into the base.html file.

I haven't brought across the fonts from the head template because nothing uses them at the moment.
I have also commented out all url tags within the template files as they are not defined yet and is therefore out of scope for this work. This also applies to the form within the basic_search_form template.
I have also commented out the original `for` loop syntax within browse_by_court template to keep as reference.